### PR TITLE
Fix last move distance calculation (not working)

### DIFF
--- a/plugin2026/src/main/kotlin/sc/plugin2026/Board.kt
+++ b/plugin2026/src/main/kotlin/sc/plugin2026/Board.kt
@@ -7,8 +7,6 @@ import sc.framework.deepCopy
 import sc.plugin2026.util.PiranhaConstants
 import kotlin.random.Random
 
-val line = "-".repeat(PiranhaConstants.BOARD_LENGTH * 2 + 2)
-
 /** Spielbrett für Piranhas mit [PiranhaConstants.BOARD_LENGTH]² Feldern.  */
 @XStreamAlias(value = "board")
 class Board(
@@ -24,12 +22,14 @@ class Board(
         }
     
     fun prettyString(): String {
+        val line = "-".repeat(gameField.first().size * 2 + 2)
         val map = StringBuilder(line)
         gameField.forEach { row ->
             map.append("\n|")
             row.forEach { field ->
                 map.append(field.asLetters())
             }
+            map.append("|")
         }
         map.append("\n").append(line)
         return map.toString()

--- a/plugin2026/src/main/kotlin/sc/plugin2026/util/GameRuleLogic.kt
+++ b/plugin2026/src/main/kotlin/sc/plugin2026/util/GameRuleLogic.kt
@@ -15,7 +15,7 @@ object GameRuleLogic {
      * @return wie viele Felder weit der Zug sein sollte */
     @JvmStatic
     fun movementDistance(board: Board, move: Move): Int {
-        var count = 1
+        var count = 0
         var pos = move.from
         while(true) {
             pos += move.direction
@@ -32,6 +32,14 @@ object GameRuleLogic {
                 count++
             }
         }
+        
+        pos = move.from
+        val field = board.getOrNull(pos)
+        if(field?.team != null) {
+            count++
+        }
+        
+        
         return count
     }
     

--- a/plugin2026/src/main/kotlin/sc/plugin2026/util/GameRuleLogic.kt
+++ b/plugin2026/src/main/kotlin/sc/plugin2026/util/GameRuleLogic.kt
@@ -16,6 +16,10 @@ object GameRuleLogic {
     @JvmStatic
     fun movementDistance(board: Board, move: Move): Int {
         var count = 0
+        if(board.getOrNull(move.from)?.team != null) {
+            count++
+        }
+        
         var pos = move.from
         while(true) {
             pos += move.direction
@@ -24,6 +28,7 @@ object GameRuleLogic {
                 count++
             }
         }
+        
         pos = move.from
         while(true) {
             pos += move.direction.opposite
@@ -32,13 +37,6 @@ object GameRuleLogic {
                 count++
             }
         }
-        
-        pos = move.from
-        val field = board.getOrNull(pos)
-        if(field?.team != null) {
-            count++
-        }
-        
         
         return count
     }

--- a/plugin2026/src/test/kotlin/sc/plugin2026/GameRuleLogicTest.kt
+++ b/plugin2026/src/test/kotlin/sc/plugin2026/GameRuleLogicTest.kt
@@ -52,5 +52,41 @@ class GameRuleLogicTest: FunSpec({
             GameRuleLogic.checkMove(board, Move(fish, Direction.UP_LEFT)) shouldBe null
             GameRuleLogic.possibleMovesFor(board, fish) shouldHaveSize 3
         }
+        test("check movementDistance before and after moving") {
+            // Construct a tiny deterministic board (1x5) with fishes aligned horizontally.
+            val fields = arrayOf(arrayOf(
+                FieldState.EMPTY,
+                FieldState.TWO_S,
+                FieldState.ONE_S,
+                FieldState.EMPTY,
+                FieldState.ONE_S,
+            ))
+            val state = GameState(board = Board(fields))
+            state.board.prettyString() shouldBe """
+                ------------
+                |  B1R1  R1|
+                ------------
+            """.trimIndent()
+            
+            val move = Move(Coordinates(4,0), Direction.LEFT)
+            // Sanity: move is valid and has distance 3
+            GameRuleLogic.movementDistance(state.board, move) shouldBe 3
+            GameRuleLogic.checkMove(state.board, move) shouldBe null
+            GameRuleLogic.targetCoordinates(state.board, move) shouldBe Coordinates(1, 0)
+            state.performMoveDirectly(move)
+            
+            state.board.prettyString() shouldBe """
+                ------------
+                |  R1R1    |
+                ------------
+            """.trimIndent()
+            
+            val next = Move(Coordinates(1, 0), Direction.RIGHT)
+            GameRuleLogic.movementDistance(state.board, next) shouldBe 2
+            GameRuleLogic.checkMove(state.board, next) shouldBe null
+            
+            // FIXME this test fails because the piranha that was eaten is gone
+            GameRuleLogic.movementDistance(state.board, state.lastMove!!) shouldBe 3
+        }
     }
 })


### PR DESCRIPTION
Besteht alle Tests aber funktioniert nicht als build

Bug: movementDistance errechnet falsche Distanz für LastMove-Züge, da er den Piranha der gezogen wurde doppelt zählt (Am Anfang (Leeres Feld, weil neues Board -> Fehler) und dann nochmal, wenn er über die anderen Felder iteriert.

@TomekRD 